### PR TITLE
set override redirect flag for ui window

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -504,11 +504,20 @@ int uiShow(bool direction)
 		XftFontClose(dpy, fontLabel);
 
 // prepare our window
-	uiwin = XCreateSimpleWindow(dpy, root,
-				    uiwinX, uiwinY,
-				    uiwinW, uiwinH,
-				    0, g.color[COLFRAME].xcolor.pixel,
-				    g.color[COLBG].xcolor.pixel);
+	unsigned long valuemask = CWBackPixel | CWBorderPixel | CWOverrideRedirect;
+	XSetWindowAttributes attributes;
+	attributes.background_pixel = g.color[COLBG].xcolor.pixel;
+	attributes.border_pixel = g.color[COLFRAME].xcolor.pixel;
+	attributes.override_redirect = 1;
+	uiwin = XCreateWindow(
+				dpy, root,
+				uiwinX, uiwinY,
+				uiwinW, uiwinH,
+				0, // border_width
+				CopyFromParent, // depth
+				InputOutput, // class
+				CopyFromParent, // visual
+				valuemask, &attributes);
 	if (uiwin <= 0)
 		die("can't create window");
 	if (g.debug > 0) {


### PR DESCRIPTION
This sets the override redirect flag for the gui window, so that it is not be tampered with by the window manager, i.e. it will not be focused or positioned.

For me, this also fixes moving windows (from center to top) when using `-p none` in i3.