### PR TITLE
Cleanup v2

### DIFF
--- a/src/alttab.c
+++ b/src/alttab.c
@@ -43,7 +43,7 @@ Window root;
 //
 // help and exit
 //
-void helpexit()
+static void helpexit()
 {
     msg(-1, "the task switcher, v%s\n\
 Options:\n\
@@ -76,7 +76,7 @@ See man alttab for details.\n", PACKAGE_VERSION);
 // return 1 if success, 0 otherwise
 // on fatal failure, calls die/exit
 //
-int use_args_and_xrm(int *argc, char **argv)
+static int use_args_and_xrm(int *argc, char **argv)
 {
 // set debug level early
     g.debug = 0;
@@ -427,7 +427,7 @@ int use_args_and_xrm(int *argc, char **argv)
 // grab Alt-Tab and Alt-Shift-Tab
 // note: exit() on failure
 //
-int grabAllKeys(bool grabUngrab)
+static int grabAllKeys(bool grabUngrab)
 {
     g.ignored_modmask = getOffendingModifiersMask(dpy); // or 0 for g.debug
     char *grabhint =

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -415,7 +415,7 @@ static int use_args_and_xrm(int *argc, char **argv)
     }
 
 // max recursion for searching windows
-// -1 is "everything" 
+// -1 is "everything"
 // in raw X this returns too much windows, "1" is probably sufficient
 // no need for an option
     g.option_max_reclevel = (g.option_wm == WM_NO) ? 1 : -1;

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -39,6 +39,7 @@ int scr;
 Window root;
 
 // PRIVATE
+static XrmDatabase db;
 
 //
 // help and exit
@@ -80,7 +81,6 @@ static int use_args_and_xrm(int *argc, char **argv)
 {
 // set debug level early
     g.debug = 0;
-    XrmDatabase db;
     char *errmsg;
     int ksi;
     KeyCode BC;
@@ -559,6 +559,9 @@ int main(int argc, char **argv)
     }
 
 // this is probably never reached
+    shutdownWin();
+    shutdownGUI();
+    XrmDestroyDatabase(db);
     grabAllKeys(false);
 // not restoring error handler
     XCloseDisplay(dpy);

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -79,7 +79,7 @@ typedef struct {
     unsigned int icon_w, icon_h;
     bool icon_allocated;        // we must free icon, because we created it (placeholder or depth conversion)
     Pixmap tile;                // ready to display. w/h are all equal and defined in gui.c
-// this constant can't be 0, 1, -1, MAXINT, 
+// this constant can't be 0, 1, -1, MAXINT,
 // because WMs set it to these values incoherently
 #define DESKTOP_UNKNOWN 0xdead
     unsigned long desktop;

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -118,7 +118,6 @@ typedef struct {
     bool uiShowHasRun;          // means: 1. window is ready to Expose, 2. need to call uiHide to free X stuff
     WindowInfo *winlist;
     int maxNdx;                 // number of items in list above
-    int selNdx;                 // current (selected) item
     /* auxiliary list for sorting
      * head = recently focused
      * display-wide, for all groups/desktops
@@ -203,7 +202,7 @@ int addIconFromHints(WindowInfo * wi);
 int addIconFromFiles(WindowInfo * wi);
 int addWindowInfo(Window win, int reclevel, int wm_id, unsigned long desktop,
                   char *wm_name);
-int initWinlist(bool direction);
+int initWinlist(void);
 void freeWinlist();
 int setFocus(int winNdx);
 int rp_startupWintasks();

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -195,6 +195,7 @@ int uiPrevWindow();
 int uiSelectWindow(int ndx);
 void uiButtonEvent(XButtonEvent e);
 Window getUiwin();
+void shutdownGUI(void);
 
 // windows
 int startupWintasks();
@@ -219,6 +220,7 @@ bool common_skipWindow(Window w, unsigned long current_desktop,
                        unsigned long window_desktop);
 void x_setCommonPropertiesForAnyWindow(Window win);
 void addToSortlist(Window w, bool to_head, bool move);
+void shutdownWin(void);
 
 /* EWHM */
 bool ewmh_detectFeatures(EwmhFeatures * e);

--- a/src/ewmh.c
+++ b/src/ewmh.c
@@ -41,7 +41,7 @@ extern Window root;
 // returns ptr to EWMH client list and client_list_size
 // or NULL
 //
-Window *ewmh_get_client_list(unsigned long *client_list_size)
+static Window *ewmh_get_client_list(unsigned long *client_list_size)
 {
     Window *client_list;
 
@@ -67,7 +67,7 @@ Window *ewmh_get_client_list(unsigned long *client_list_size)
     return 0;
 }
 
-int ewmh_send_wm_evt(Window w, char *atom, unsigned long edata[])
+static int ewmh_send_wm_evt(Window w, char *atom, unsigned long edata[])
 {
     XEvent evt;
     long rn_mask = SubstructureRedirectMask | SubstructureNotifyMask;
@@ -88,7 +88,7 @@ int ewmh_send_wm_evt(Window w, char *atom, unsigned long edata[])
     return 1;
 }
 
-int ewmh_switch_desktop(unsigned long desktop)
+static int ewmh_switch_desktop(unsigned long desktop)
 {
     int evr, elapsed;
     unsigned long edata[] = { desktop, CurrentTime, 0, 0, 0 };
@@ -110,7 +110,7 @@ int ewmh_switch_desktop(unsigned long desktop)
     return evr;
 }
 
-int ewmh_switch_window(unsigned long window)
+static int ewmh_switch_window(unsigned long window)
 {
     unsigned long edata[] = { 2, CurrentTime, 0, 0, 0 };
     msg(1, "ewmh switching window to 0x%lx\n", window);

--- a/src/gui.c
+++ b/src/gui.c
@@ -36,16 +36,16 @@ extern Window root;
 
 // PRIVATE
 
-unsigned int tileW, tileH, iconW, iconH;
-unsigned int visualTileW;
-int lastPressedTile;
-quad scrdim;
-Window uiwin;
-int uiwinW, uiwinH, uiwinX, uiwinY;
-Colormap colormap;
-Visual *visual;
+static unsigned int tileW, tileH, iconW, iconH;
+static unsigned int visualTileW;
+static int lastPressedTile;
+static quad scrdim;
+static Window uiwin;
+static int uiwinW, uiwinH, uiwinX, uiwinY;
+static Colormap colormap;
+static Visual *visual;
 //Font fontLabel;  // Xft instead
-XftFont *fontLabel;
+static XftFont *fontLabel;
 
 //
 // allocates GC
@@ -54,7 +54,7 @@ XftFont *fontLabel;
 //   1: for bg fill
 //   2: for drawing frame
 //
-GC create_gc(int type)
+static GC create_gc(int type)
 {
     GC gc;                      /* handle of newly created GC.  */
     unsigned long valuemask = 0;    /* which values in 'values' to  */
@@ -98,7 +98,7 @@ GC create_gc(int type)
 //
 // single use helper for function below
 //
-void drawFr(GC gc, int f)
+static void drawFr(GC gc, int f)
 {
     int d = XDrawRectangle(dpy, uiwin, gc,
                            f * (tileW + FRAME_W) + (FRAME_W / 2),
@@ -112,7 +112,7 @@ void drawFr(GC gc, int f)
 //
 // draw selected and unselected frames around tiles
 //
-void framesRedraw()
+static void framesRedraw()
 {
     int f;
     for (f = 0; f < g.maxNdx; f++) {
@@ -129,7 +129,7 @@ void framesRedraw()
 // given coordinates relative to our window,
 // return the tile number or -1
 //
-int pointedTile(int x, int y)
+static int pointedTile(int x, int y)
 {
     if (x < (FRAME_W / 2)
         || x > (uiwinW - (FRAME_W / 2))
@@ -142,7 +142,7 @@ int pointedTile(int x, int y)
 // combine widgets into wi->tile
 // for uiShow()
 //
-void prepareTile(WindowInfo * wi)
+static void prepareTile(WindowInfo * wi)
 {
     wi->tile = XCreatePixmap(dpy, root, tileW, tileH, XDEPTH);
     if (!wi->tile)

--- a/src/gui.c
+++ b/src/gui.c
@@ -368,12 +368,8 @@ int uiShow(bool direction)
 // GC,
 // g.vp (for SCR_CURRENT)
 
-    g.winlist = NULL;
-    g.maxNdx = 0;
     if (!initWinlist()) {
         msg(0, "initWinlist failed, skipping ui initialization\n");
-        g.winlist = NULL;
-        g.maxNdx = 0;
         return 0;
     }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -49,7 +49,7 @@ static XftFont *fontLabel;
 
 //
 // allocates GC
-// type is: 
+// type is:
 //   0: normal
 //   1: for bg fill
 //   2: for drawing frame
@@ -153,7 +153,7 @@ static void prepareTile(WindowInfo * wi)
         msg(-1, "can't fill tile\n");
     }
     // mini-window content could be drawn here,
-    // but there is no backing store of windows 
+    // but there is no backing store of windows
     // in my simple environments (as reported by xwininfo)
     //
     // place icons
@@ -232,7 +232,7 @@ static void prepareTile(WindowInfo * wi)
 // early initialization
 // called once per execution
 // mostly initializes g.*
-// TODO: counterpair for freeing X resources, 
+// TODO: counterpair for freeing X resources,
 //   even if called once per execution:
 /*
 int p; for (p=0; p<NCOLORS; p++) {
@@ -534,7 +534,7 @@ int uiShow(bool direction)
 
     // positioning and size hints.
     // centering required in JWM.
-    // should really perform centering when 
+    // should really perform centering when
     //  viewport == wm screen. how would we know the latter?
     long sflags;
     sflags =

--- a/src/gui.c
+++ b/src/gui.c
@@ -46,6 +46,7 @@ static Colormap colormap;
 static Visual *visual;
 //Font fontLabel;  // Xft instead
 static XftFont *fontLabel;
+static int selNdx;                 // current (selected) item
 
 //
 // allocates GC
@@ -116,13 +117,13 @@ static void framesRedraw()
 {
     int f;
     for (f = 0; f < g.maxNdx; f++) {
-        if (f == g.selNdx)
+        if (f == selNdx)
             continue;           // skip
         drawFr(g.gcReverse, f); // thick bg
         drawFr(g.gcDirect, f);  // thin frame
     }
 // _after_ unselected draw selected, because they may overlap
-    drawFr(g.gcFrame, g.selNdx);
+    drawFr(g.gcFrame, selNdx);
 }
 
 //
@@ -369,12 +370,13 @@ int uiShow(bool direction)
 
     g.winlist = NULL;
     g.maxNdx = 0;
-    if (!initWinlist(direction)) {
+    if (!initWinlist()) {
         msg(0, "initWinlist failed, skipping ui initialization\n");
         g.winlist = NULL;
         g.maxNdx = 0;
         return 0;
     }
+
     if (!g.winlist) {
         msg(0, "winlist doesn't exist, skipping ui initialization\n");
         return 0;
@@ -383,6 +385,11 @@ int uiShow(bool direction)
         msg(0, "number of windows < 1, skipping ui initialization\n");
         return 0;
     }
+
+    selNdx = direction ? (g.maxNdx - 1) : ((0 >= (g.maxNdx - 1)) ? 0 : 1);
+//if (selNdx<0 || selNdx>=g.maxNdx) { selNdx=0; } // just for case
+    msg(1, "Current (selected) item in winlist: %d\n", selNdx);
+
     if (g.debug > 0) {
         msg(0, "got %d windows\n", g.maxNdx);
         int i;
@@ -613,15 +620,15 @@ int uiHide()
         uiwin = 0;
     }
     if (g.winlist) {
-        msg(0, "changing focus to 0x%lx\n", g.winlist[g.selNdx].id);
+        msg(0, "changing focus to 0x%lx\n", g.winlist[selNdx].id);
         /*
            // save the switch moment for detecting
            // subsequent false focus event from WM
            gettimeofday(&(g.last.tv), NULL);
            g.last.prev = g.winlist[g.startNdx].id;
-           g.last.to = g.winlist[g.selNdx].id;
+           g.last.to = g.winlist[selNdx].id;
          */
-        setFocus(g.selNdx);     // before winlist destruction!
+        setFocus(selNdx);     // before winlist destruction!
     }
     msg(0, "destroying tiles\n");
     int y;
@@ -645,10 +652,10 @@ int uiNextWindow()
 {
     if (!uiwin)
         return 0;               // kb events may trigger it even when no window drawn yet
-    g.selNdx++;
-    if (g.selNdx >= g.maxNdx)
-        g.selNdx = 0;
-    msg(0, "item %d\n", g.selNdx);
+    selNdx++;
+    if (selNdx >= g.maxNdx)
+        selNdx = 0;
+    msg(0, "item %d\n", selNdx);
     framesRedraw();
     return 1;
 }
@@ -660,10 +667,10 @@ int uiPrevWindow()
 {
     if (!uiwin)
         return 0;               // kb events may trigger it even when no window drawn yet
-    g.selNdx--;
-    if (g.selNdx < 0)
-        g.selNdx = g.maxNdx - 1;
-    msg(0, "item %d\n", g.selNdx);
+    selNdx--;
+    if (selNdx < 0)
+        selNdx = g.maxNdx - 1;
+    msg(0, "item %d\n", selNdx);
     framesRedraw();
     return 1;
 }
@@ -678,8 +685,8 @@ int uiSelectWindow(int ndx)
     if (ndx < 0 || ndx >= g.maxNdx) {
         return 0;
     }
-    g.selNdx = ndx;
-    msg(0, "item %d\n", g.selNdx);
+    selNdx = ndx;
+    msg(0, "item %d\n", selNdx);
     framesRedraw();
     return 1;
 }

--- a/src/gui.c
+++ b/src/gui.c
@@ -232,17 +232,7 @@ static void prepareTile(WindowInfo * wi)
 // early initialization
 // called once per execution
 // mostly initializes g.*
-// TODO: counterpair for freeing X resources,
-//   even if called once per execution:
-/*
-int p; for (p=0; p<NCOLORS; p++) {
-        XftColorFree (dpy,DefaultVisual(dpy,0),DefaultColormap(dpy,0),g.color[p].xftcolor);
-            // XFreeColors ?
-}
-if (g.gcDirect) XFreeGC (dpy, g.gcDirect);
-if (g.gcReverse) XFreeGC (dpy, g.gcReverse);
-if (g.gcFrame) XFreeGC (dpy, g.gcFrame);
-*/
+
 int startupGUItasks()
 {
 // if viewport is not fixed, then initialize vp* at every show
@@ -728,4 +718,26 @@ void uiButtonEvent(XButtonEvent e)
 Window getUiwin()
 {
     return uiwin;
+}
+
+void shutdownGUI(void)
+{
+    int p;
+
+    for (p=0; p<NCOLORS; p++) {
+        XftColorFree(dpy,
+                     DefaultVisual(dpy,0),
+                     DefaultColormap(dpy,0),
+                     &g.color[p].xftcolor);
+            // XFreeColors ?
+    }
+
+    //XftFontClose(dpy, fontLabel); // actually, not needed
+
+    if (g.gcDirect)
+        XFreeGC(dpy, g.gcDirect);
+    if (g.gcReverse)
+        XFreeGC(dpy, g.gcReverse);
+    if (g.gcFrame)
+        XFreeGC (dpy, g.gcFrame);
 }

--- a/src/icon.c
+++ b/src/icon.c
@@ -249,7 +249,7 @@ int inspectIconFile(FTSENT * pe)
     }
 
     return 1;
-}                               // inspectIconFile 
+}                               // inspectIconFile
 
 //
 // update drawable

--- a/src/icon.c
+++ b/src/icon.c
@@ -100,6 +100,7 @@ int updateIconsFromFile(icon_t ** ihash)
     int idndx = 0;
     int theme_len = strlen(g.option_theme);
     char *home = getenv("HOME");
+    int ret = 0;
 
     for (hd = 0; icondir[hd] != NULL; hd++) {
         id2len = strlen(icondir[hd]) + 1 + theme_len + 1;
@@ -128,12 +129,12 @@ int updateIconsFromFile(icon_t ** ihash)
 
     if ((ftsp = fts_open(icon_dirs, fts_options, NULL)) == NULL) {
         warn("fts_open");
-        return 0;
+        goto out;
     }
     /* Initialize ftsp with as many icon_dirs as possible. */
     chp = fts_children(ftsp, 0);
     if (chp == NULL) {
-        return 0;               /* no files to traverse */
+        goto out;               /* no files to traverse */
     }
     d_c = f_c = 0;
     while ((p = fts_read(ftsp)) != NULL) {
@@ -162,7 +163,14 @@ int updateIconsFromFile(icon_t ** ihash)
             }
         }
     }
-    return 1;
+
+    ret = 1;
+
+out:
+    for (idndx = 0; icon_dirs[idndx] != NULL; idndx++)
+        free(icon_dirs[idndx]);
+
+    return ret;
 }                               // updateIconsFromFile
 
 //
@@ -309,4 +317,15 @@ bool iconMatchBetter(int new_w, int new_h, int old_w, int old_h)
                                                     hasdiff) ? true : false)
         ) : ((newdiff >= 0) ? true : ((newdiff > hasdiff) ? true : false)
         );
+}
+
+void deleteIconHash(icon_t **ihash)
+{
+    icon_t *iiter, *tmp;
+
+    HASH_ITER(hh, *ihash, iiter, tmp) {
+        HASH_DEL(*ihash, iiter);
+        if (iiter != NULL)
+            deleteIcon(iiter);
+    }
 }

--- a/src/icon.h
+++ b/src/icon.h
@@ -56,5 +56,6 @@ int inspectIconFile(FTSENT * pe);   // check if file pe has better icon than we 
 int loadIconContent(icon_t * ic);   // update drawable
 icon_t *lookupIcon(char *app);  // search app icon in hash
 bool iconMatchBetter(int new_w, int new_h, int old_w, int old_h);
+void deleteIconHash(icon_t **ihash);
 
 #endif

--- a/src/pngd.c
+++ b/src/pngd.c
@@ -19,6 +19,7 @@ along with alttab.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <unistd.h>
+#include <X11/Xutil.h>
 #include "pngd.h"
 
 extern Display *dpy;
@@ -62,6 +63,12 @@ int pngInit(FILE * infile, TImage * img)
     img->info_ptr = info_ptr;
 
     return 1;
+}
+
+static void pngFree(TImage *img)
+{
+    png_destroy_read_struct(&img->png_ptr, &img->info_ptr, NULL);
+    free(img->data);
 }
 
 //
@@ -229,6 +236,7 @@ int pngReadToDrawable(char *pngpath, Drawable d, uint8_t bg_red,
     int pad;
     XImage *ximage;
     int depth;
+    int ret;
 
     img.data = NULL;
     img.png_ptr = NULL;
@@ -273,7 +281,10 @@ int pngReadToDrawable(char *pngpath, Drawable d, uint8_t bg_red,
     }
     ximage->byte_order = MSBFirst;
 
-    return pngDraw(&img, d, ximage, visual, bg_red, bg_green, bg_blue);
+    ret = pngDraw(&img, d, ximage, visual, bg_red, bg_green, bg_blue);
+    pngFree(&img);
+    XDestroyImage(ximage);
+    return ret;
 }
 
 //

--- a/src/randr.c
+++ b/src/randr.c
@@ -31,10 +31,10 @@ extern Display *dpy;
 extern int scr;
 extern Window root;
 
-// Documentation: 
+// Documentation:
 // https://cgit.freedesktop.org/xorg/proto/randrproto/tree/randrproto.txt
 
-// version requirements: 
+// version requirements:
 // RRGetScreenResourcesCurrent (1.3)
 #define MAJ_REQ 1
 #define MIN_REQ 3
@@ -226,7 +226,7 @@ bool randrGetViewport(quad * res, bool * multihead)
                 largest_cross_area = area;
             }
             /*
-               // disabled feature: 
+               // disabled feature:
                // total area of CRTCs which have cross-section with focused window
                if (oq[o].x < res->x) res->x = oq[o].x;
                int right_diff = (oq[o].x + oq[o].w) - (res->x + res->w);
@@ -247,7 +247,7 @@ bool randrGetViewport(quad * res, bool * multihead)
         free(oq);
         return true;
     }
-    // if best cross-area is shared with some other monitor, 
+    // if best cross-area is shared with some other monitor,
     // then smallest of these monitors is choosen.
     smallest_2_stage_area =
         oq[best_1_stage_output].w * oq[best_1_stage_output].h;

--- a/src/randr.c
+++ b/src/randr.c
@@ -63,14 +63,16 @@ static int randr_update_outputs(Window w, quad ** outs)
     for (out = 0; out < scr_res->noutput; out++) {
         out_info = XRRGetOutputInfo(dpy, scr_res, scr_res->outputs[out]);
         if (out_info == NULL
-            || out_info->connection != RR_Connected || out_info->crtc == 0)
+            || out_info->connection != RR_Connected || out_info->crtc == 0) {
+            XRRFreeOutputInfo(out_info); // does it neen NULL check?
             continue;
+        }
         crtc_info = XRRGetCrtcInfo(dpy, scr_res, out_info->crtc);
         if (crtc_info == NULL)
             continue;
         (*outs) = realloc((*outs), (nout + 1) * sizeof(quad));
         if ((*outs) == NULL)
-            return 0;
+            return 0; // would be nice to free Infos
         (*outs)[nout].x = crtc_info->x;
         (*outs)[nout].y = crtc_info->y;
         (*outs)[nout].w = crtc_info->width;
@@ -84,7 +86,7 @@ static int randr_update_outputs(Window w, quad ** outs)
         XRRFreeOutputInfo(out_info);
         nout++;
     }
-    //XRRFreeScreenResources(scr_res);  // don't do this for XRRGetScreenResourcesCurrent?
+    XRRFreeScreenResources(scr_res);
     return nout;
 }
 

--- a/src/randr.c
+++ b/src/randr.c
@@ -47,7 +47,7 @@ extern Window root;
 //
 // update outs, return nout or 0
 //
-int randr_update_outputs(Window w, quad ** outs)
+static int randr_update_outputs(Window w, quad ** outs)
 {
     XRRScreenResources *scr_res;
     XRROutputInfo *out_info;
@@ -93,7 +93,7 @@ int randr_update_outputs(Window w, quad ** outs)
 // or focus point (depending on vp_mode).
 // res and fw must be allocated by caller.
 //
-bool x_get_activity_area(quad * res, Window * fw)
+static bool x_get_activity_area(quad * res, Window * fw)
 {
 #define VPM  g.option_vp_mode
     int rtr;

--- a/src/rp.c
+++ b/src/rp.c
@@ -35,14 +35,14 @@ extern Globals g;
 
 #define RP_MAXGROUPS    64
 
-char *ratpoison_cmd;
+static char *ratpoison_cmd;
 
 //
 // process ratpoison window_group, adding its windows 
 // to winlist/sortlist.
 // window_group must be selected in advance.
 //
-int rp_add_windows_in_group(int current_group, int window_group)
+static int rp_add_windows_in_group(int current_group, int window_group)
 {
     char *args[] = { "ratpoison", "-c", "windows %n %i %s %t", NULL };
     char buf[MAXRPOUT];

--- a/src/rp.c
+++ b/src/rp.c
@@ -38,7 +38,7 @@ extern Globals g;
 static char *ratpoison_cmd;
 
 //
-// process ratpoison window_group, adding its windows 
+// process ratpoison window_group, adding its windows
 // to winlist/sortlist.
 // window_group must be selected in advance.
 //
@@ -223,7 +223,7 @@ int rp_setFocus(int winNdx)
     char *args[] = { "ratpoison", "-c", selarg, NULL };
     char buf[MAXRPOUT];
 
-    // don't skip changing group if it's current, because 
+    // don't skip changing group if it's current, because
     // rp_initWinlist left current group inconsistent
     if (g.winlist[winNdx].desktop != DESKTOP_UNKNOWN) {
         snprintf(selarg, 63, "gselect %lu", g.winlist[winNdx].desktop);

--- a/src/util.c
+++ b/src/util.c
@@ -607,6 +607,21 @@ char *get_x_property(Window win, Atom prop_type, char *prop_name,
     return r;
 }
 
+char *get_x_property_alt(Window win,
+			 Atom prop_type1, char *prop_name1,
+			 Atom prop_type2, char *prop_name2,
+			 unsigned long *prop_size)
+{
+    char *p;
+
+    p = get_x_property(win, prop_type1, prop_name1, prop_size);
+    if (p != NULL)
+        return p;
+
+    p = get_x_property(win, prop_type2, prop_name2, prop_size);
+    return p;
+}
+
 //
 // do rectangles cross?
 //

--- a/src/util.c
+++ b/src/util.c
@@ -62,7 +62,7 @@ unsigned int getOffendingModifiersMask()
 //
 // for ignoring X errors
 // https://tronche.com/gui/x/xlib/event-handling/protocol-errors/default-handlers.html#XErrorEvent
-// 
+//
 int zeroErrorHandler(Display * dpy_our, XErrorEvent * theEvent)
 {
     ee_ignored = theEvent;
@@ -379,7 +379,7 @@ char *utf8index(char *s, size_t pos)
 }
 
 //
-// Draw utf-8 string str on window/pixmap d, 
+// Draw utf-8 string str on window/pixmap d,
 // using *font and *xrcolor,
 // splitting and cropping it to fit (x1,y1 - x1+width,y1+height) rectangle.
 // Return 1 if ok.
@@ -737,7 +737,7 @@ int ksym_option_to_keycode(XrmDatabase * db, const char *appname,
 // return first modifier corresponding to given keycode,
 // in the form of modmask,
 // or zero if not found
-// 
+//
 unsigned int keycode_to_modmask(KeyCode kc)
 {
     int mi, ksi;

--- a/src/util.c
+++ b/src/util.c
@@ -743,14 +743,19 @@ unsigned int keycode_to_modmask(KeyCode kc)
     int mi, ksi;
     KeyCode tkc;
     XModifierKeymap *xmk = XGetModifierMapping(dpy);
+    unsigned int ret = 0;
 
     for (mi = 0; mi < 8; mi++) {
         for (ksi = 0; ksi < xmk->max_keypermod; ksi++) {
             tkc = (xmk->modifiermap)[xmk->max_keypermod * mi + ksi];
             if (tkc == kc) {
-                return (1 << mi);
+                ret = (1 << mi);
+                goto out;
             }
         }
     }
-    return 0;
+
+out:
+    XFreeModifiermap(xmk);
+    return ret;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -79,6 +79,10 @@ Bool predproc_true(Display * display, XEvent * event, char *arg);
 
 char *get_x_property(Window win, Atom prop_type, char *prop_name,
                      unsigned long *prop_size);
+char *get_x_property_alt(Window win,
+			 Atom prop_type1, char *prop_name1,
+			 Atom prop_type2, char *prop_name2,
+			 unsigned long *prop_size);
 
 bool rectangles_cross(quad a, quad b);
 bool get_absolute_coordinates(Window w, quad * q);

--- a/src/win.c
+++ b/src/win.c
@@ -386,12 +386,12 @@ int addWindowInfo(Window win, int reclevel, int wm_id, unsigned long desktop,
 }                               // addWindowInfo()
 
 //
-// sets g.winlist, g.maxNdx, g.selNdx
+// sets g.winlist, g.maxNdx
 // updates g.sortlist, g.sortNdx
 // n.b.: in heavy WM, use _NET_CLIENT_LIST
 // direction is direction of first press: with shift or without
 //
-int initWinlist(bool direction)
+int initWinlist(void)
 {
     int r;
     if (g.debug > 1) {
@@ -428,11 +428,7 @@ int initWinlist(bool direction)
         print_winlist();
     }
 
-    g.selNdx = direction ? (g.maxNdx - 1) : ((0 >= (g.maxNdx - 1)) ? 0 : 1);
-//if (g.selNdx<0 || g.selNdx>=g.maxNdx) { g.selNdx=0; } // just for case
-    msg(1,
-        "initWinlist ret: number of items in winlist: %d, current (selected) item in winlist: %d\n",
-        g.maxNdx, g.selNdx);
+    msg(1, "initWinlist ret: number of items in winlist: %d\n", g.maxNdx);
 
     return r;
 }

--- a/src/win.c
+++ b/src/win.c
@@ -225,7 +225,7 @@ int addIconFromHints(WindowInfo * wi)
 //
 // search for "wi" application class in PNG hash.
 // if found, then
-//   if program options don't request size comparison 
+//   if program options don't request size comparison
 //   OR png size match better, then
 //     fill in "wi->icon_pixmap" and "wi->icon_mask"
 //     and return 1
@@ -533,7 +533,7 @@ void winPropChangeEvent(XPropertyEvent e)
         struct timeval ctv;
         int usec_delta;
         gettimeofday(&ctv, NULL);
-        usec_delta = (ctv.tv_sec - g.last.tv.tv_sec) * 1E6 
+        usec_delta = (ctv.tv_sec - g.last.tv.tv_sec) * 1E6
           + (ctv.tv_usec - g.last.tv.tv_usec);
         msg(0, "delta %d\n", usec_delta);
         if (usec_delta < 5E5) {  // half a second
@@ -631,7 +631,7 @@ void winFocusChangeEvent(XFocusChangeEvent e)
 {
     Window w;
     // in non-EWMH only
-    // probably should also maintain _NET_ACTIVE_WINDOW 
+    // probably should also maintain _NET_ACTIVE_WINDOW
     // support flag in EwmhFeatures
     if (g.option_wm == WM_EWMH)
         return;

--- a/src/win.c
+++ b/src/win.c
@@ -66,7 +66,7 @@ static int sort_by_order(const void *p1, const void *p2)
 //
 // debug output of sortlist
 //
-void print_sortlist()
+static void print_sortlist()
 {
     PermanentWindowInfo *s;
     msg(0, "sortlist:\n");
@@ -78,7 +78,7 @@ void print_sortlist()
 //
 // debug output of winlist
 //
-void print_winlist()
+static void print_winlist()
 {
     int wi, si;
     PermanentWindowInfo *s;

--- a/src/win.c
+++ b/src/win.c
@@ -385,6 +385,14 @@ int addWindowInfo(Window win, int reclevel, int wm_id, unsigned long desktop,
     return 1;
 }                               // addWindowInfo()
 
+static void __initWinlist(void)
+{
+    free(g.winlist);
+    g.winlist = NULL;
+    g.maxNdx = 0;
+}
+
+
 //
 // sets g.winlist, g.maxNdx
 // updates g.sortlist, g.sortNdx
@@ -415,6 +423,9 @@ int initWinlist(void)
         r = 0;
         break;
     }
+
+    if (!r)
+        __initWinlist();
 
 // sort winlist according to .order
     if (g.debug > 1) {
@@ -449,7 +460,7 @@ void freeWinlist()
         if (g.winlist[y].icon_allocated)
             XFreePixmap(dpy, g.winlist[y].icon_drawable);
     }
-    free(g.winlist);
+    __initWinlist();
 }
 
 //

--- a/src/win.c
+++ b/src/win.c
@@ -150,7 +150,6 @@ int startupWintasks()
     g.sortlist = NULL;          // utlist head must be initialized to NULL
     g.ic = NULL;                // uthash too
     if (g.option_iconSrc != ISRC_RAM) {
-        g.ic = initIcon();
         initIconHash(&(g.ic));
     }
     // root: watching for _NET_ACTIVE_WINDOW
@@ -237,6 +236,7 @@ int addIconFromFiles(WindowInfo * wi)
     char *appclass, *tryclass;
     long unsigned int class_size;
     icon_t *ic;
+    int ret = 0;
 
     appclass = get_x_property(wi->id, XA_STRING, "WM_CLASS", &class_size);
     if (appclass) {
@@ -258,13 +258,16 @@ int addIconFromFiles(WindowInfo * wi)
                 }
                 wi->icon_drawable = ic->drawable;
                 wi->icon_mask = 0;
-                return 1;
+                ret = 1;
+                goto out;
             }
         }
     } else {
         msg(0, "can't find WM_CLASS for \"%s\"\n", wi->name);
     }
-    return 0;
+out:
+    free(appclass);
+    return ret;
 }
 
 //
@@ -651,4 +654,9 @@ void winFocusChangeEvent(XFocusChangeEvent e)
 
     msg(1, "event focusIn 0x%lx, pull to the head of sortlist\n", w);
     addToSortlist(w, true, true);
+}
+
+void shutdownWin()
+{
+    deleteIconHash(&g.ic);
 }

--- a/src/x.c
+++ b/src/x.c
@@ -138,7 +138,7 @@ int x_setFocus(int wndx)
     XRaiseWindow(dpy, w);
 
 // 3. XSetInputFocus
-// "The specified focus window must be viewable at the time 
+// "The specified focus window must be viewable at the time
 // XSetInputFocus is called, or a BadMatch error results."
 // This check is redundant: non-viewable windows isn't added to winlist in raw X anyway
     XWindowAttributes att;


### PR DESCRIPTION
- gui: skip extra winlist initializations
- gui, win: make selected window number local for gui
- ewmh: fold window property calls
- treewide: fix memory leaks
- treewide: delete trailing whitespaces
- treewide: make private stuff really private

Some notes are put in the patch descriptions. Since some cleanups are not run on SIGINT, it's a bit tricky to check memleaks.