### PR TITLE
Look in $XDG_DATA_DIRS/icons for icons

### DIFF
--- a/doc/alttab.1.ronn
+++ b/doc/alttab.1.ronn
@@ -200,8 +200,8 @@ Most command line options have corresponding X resource, see doc/alttab.ad for e
   
       /usr/share/icons  
       /usr/local/share/icons  
-      ~/.icons  
-      ~/.local/share/icons  
+      $HOME/.icons  
+      ${XDG_DATA_DIR:-$HOME/.local/share}/icons  
   
       Directory structure should obey freedesktop standard, but desktop files are ignored,
       instead file name is expected to be equal to application class. 
@@ -213,7 +213,7 @@ Most command line options have corresponding X resource, see doc/alttab.ad for e
       structure:  
   
       /usr/share/pixmaps  
-      ~/.local/share/pixmaps  
+      ${XDG_DATA_DIR:-$HOME/.local/share}/pixmaps  
 
       <2>: Prefer icon from file when it matches requested size better (see `-i` option).
 


### PR DESCRIPTION
The freedesktop standard says that we should look under
$XDG_DATA_DIRS/icons instead of ~/.local/share/icons.
We now fall back to the latter if the former doesn't exist.

Fixes #82.