### PR TITLE
Added extra next/prev keycodes (currently "h","l", left arrow, right …

### DIFF
--- a/src/alttab.c
+++ b/src/alttab.c
@@ -41,6 +41,12 @@ Window root;
 // PRIVATE
 static XrmDatabase db;
 
+// define extra next/prev keys here (used in grabAllKeys)
+#define PREV_EXTRA_KC0  43 // "h"
+#define PREV_EXTRA_KC1  113 // "left arrow"
+#define NEXT_EXTRA_KC0  46 // "l"
+#define NEXT_EXTRA_KC1  114 // "right arrow"
+
 //
 // help and exit
 //
@@ -444,6 +450,13 @@ static int grabAllKeys(bool grabUngrab)
         die(grabhint, g.option_keyCode,
             g.option_modMask | g.option_backMask, g.ignored_modmask);
     }
+
+    // grab extra keycodes (defined at top of file)
+    changeKeygrab(root, grabUngrab, PREV_EXTRA_KC0, g.option_modMask, g.ignored_modmask);
+    changeKeygrab(root, grabUngrab, PREV_EXTRA_KC1, g.option_modMask, g.ignored_modmask);
+    changeKeygrab(root, grabUngrab, NEXT_EXTRA_KC0, g.option_modMask, g.ignored_modmask);
+    changeKeygrab(root, grabUngrab, NEXT_EXTRA_KC1, g.option_modMask, g.ignored_modmask);
+
     return 1;
 }
 
@@ -502,18 +515,27 @@ int main(int argc, char **argv)
         case KeyPress:
             msg(1, "Press %lx: %d-%d\n",
                 ev.xkey.window, ev.xkey.state, ev.xkey.keycode);
-            if (!((ev.xkey.state & g.option_modMask)
-                  && ev.xkey.keycode == g.option_keyCode)) {
-                break;
-            }                   // safety redundance
+
             if (!g.uiShowHasRun) {
                 uiShow((ev.xkey.state & g.option_backMask));
             } else {
+
+                // if prev/next extra keys
+                if (ev.xkey.keycode == PREV_EXTRA_KC0 || ev.xkey.keycode == PREV_EXTRA_KC1) {
+                    uiPrevWindow();
+                    break;
+                }
+                if (ev.xkey.keycode == NEXT_EXTRA_KC0 || ev.xkey.keycode == NEXT_EXTRA_KC1) {
+                    uiNextWindow();
+                    break;
+                }
+                
                 if (ev.xkey.state & g.option_backMask) {
                     uiPrevWindow();
                 } else {
                     uiNextWindow();
                 }
+
             }
             break;
 

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -460,6 +460,23 @@ static int grabAllKeys(bool grabUngrab)
     return 1;
 }
 
+/*
+Returns 0 if not an extra prev/next keycode, 1 if extra prev keycode, and 2 if extra next keycode.
+ */
+static int isPrevNextKey(unsigned int *keycode) {
+
+    if (keycode == PREV_EXTRA_KC0 || keycode == PREV_EXTRA_KC1) {
+        return 1;
+    }
+
+    if (keycode == NEXT_EXTRA_KC0 || keycode == NEXT_EXTRA_KC1) {
+        return 2;
+    }
+
+    // if here then is neither
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
 
@@ -517,15 +534,22 @@ int main(int argc, char **argv)
                 ev.xkey.window, ev.xkey.state, ev.xkey.keycode);
 
             if (!g.uiShowHasRun) {
+
+                // if not showing uiShow and prev/next extra keys are used (i.e. without first doing alt-tab) then break
+                if (isPrevNextKey(ev.xkey.keycode) > 0) {
+                    break;
+                }
+
                 uiShow((ev.xkey.state & g.option_backMask));
+
             } else {
 
                 // if prev/next extra keys
-                if (ev.xkey.keycode == PREV_EXTRA_KC0 || ev.xkey.keycode == PREV_EXTRA_KC1) {
+                if (isPrevNextKey(ev.xkey.keycode) == 1) {
                     uiPrevWindow();
                     break;
                 }
-                if (ev.xkey.keycode == NEXT_EXTRA_KC0 || ev.xkey.keycode == NEXT_EXTRA_KC1) {
+                if (isPrevNextKey(ev.xkey.keycode) == 2) {
                     uiNextWindow();
                     break;
                 }
@@ -588,4 +612,4 @@ int main(int argc, char **argv)
 // not restoring error handler
     XCloseDisplay(dpy);
     return 0;
-}                               // main
+} // main

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -457,7 +457,7 @@ static int grabAllKeys(bool grabUngrab)
 /*
 Grabs (or releases) extra prev/next keycodes.
  */
-void grabExtraNextPrevKeys(bool grabUngrab) {
+static void grabExtraNextPrevKeys(bool grabUngrab) {
 
     // grab extra keycodes (defined at top of file)
     changeKeygrab(root, grabUngrab, PREV_EXTRA_KC0, g.option_modMask, g.ignored_modmask);
@@ -541,17 +541,10 @@ int main(int argc, char **argv)
                 ev.xkey.window, ev.xkey.state, ev.xkey.keycode);
 
             if (!g.uiShowHasRun) {
-
-                // if not showing uiShow and prev/next extra keys are used (i.e. without first doing alt-tab) then break
-                if (isPrevNextKey(ev.xkey.keycode) > 0) {
-                    break;
-                }
-
                 grabExtraNextPrevKeys(true);
                 uiShow((ev.xkey.state & g.option_backMask));
 
             } else {
-
                 // if prev/next extra keys
                 if (isPrevNextKey(ev.xkey.keycode) == 1) {
                     uiPrevWindow();
@@ -567,7 +560,6 @@ int main(int argc, char **argv)
                 } else {
                     uiNextWindow();
                 }
-
             }
             break;
 

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -451,19 +451,25 @@ static int grabAllKeys(bool grabUngrab)
             g.option_modMask | g.option_backMask, g.ignored_modmask);
     }
 
+    return 1;
+}
+
+/*
+Grabs (or releases) extra prev/next keycodes.
+ */
+void grabExtraNextPrevKeys(bool grabUngrab) {
+
     // grab extra keycodes (defined at top of file)
     changeKeygrab(root, grabUngrab, PREV_EXTRA_KC0, g.option_modMask, g.ignored_modmask);
     changeKeygrab(root, grabUngrab, PREV_EXTRA_KC1, g.option_modMask, g.ignored_modmask);
     changeKeygrab(root, grabUngrab, NEXT_EXTRA_KC0, g.option_modMask, g.ignored_modmask);
     changeKeygrab(root, grabUngrab, NEXT_EXTRA_KC1, g.option_modMask, g.ignored_modmask);
-
-    return 1;
 }
 
 /*
 Returns 0 if not an extra prev/next keycode, 1 if extra prev keycode, and 2 if extra next keycode.
  */
-static int isPrevNextKey(unsigned int *keycode) {
+static int isPrevNextKey(unsigned int keycode) {
 
     if (keycode == PREV_EXTRA_KC0 || keycode == PREV_EXTRA_KC1) {
         return 1;
@@ -517,6 +523,7 @@ int main(int argc, char **argv)
             XQueryKeymap(dpy, keys_pressed);
             if (!(keys_pressed[octet] & kmask)) {   // Alt released
                 uiHide();
+                grabExtraNextPrevKeys(false);
                 continue;
             }
             if (!XCheckIfEvent(dpy, &ev, *predproc_true, NULL)) {
@@ -540,6 +547,7 @@ int main(int argc, char **argv)
                     break;
                 }
 
+                grabExtraNextPrevKeys(true);
                 uiShow((ev.xkey.state & g.option_backMask));
 
             } else {
@@ -571,6 +579,7 @@ int main(int argc, char **argv)
                   && ev.xkey.keycode == g.option_modCode && g.uiShowHasRun)) {
                 break;
             }
+
             uiHide();
             break;
 


### PR DESCRIPTION
…arrow) defines at top of alttab.c and implemented their use in changeKeygrab and main functions.

Hey @sagb, simple enhancement which enables "h", "l" (for those vim users, like me) and left-arrow, right-arrow to move next/previous items when atltab is activated (does not interfere with default behaviour of tab, shift-tab).  

Small changes which I feel makes it significantly more natural and usable (but am open to others thoughts).  Could potentially make these options (e.g. users can define their own "extra" next/prev keys to move selected item) but I think these are intuitive and natural enough that should be defaults (thoughts?).

Cheers,
Jay.