### PR TITLE
Remove check around free()

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -186,8 +186,7 @@ bool randrGetViewport(quad * res, bool * multihead)
     if (no < 1) {
         msg(0, "randr didn't detect any output\n");
         *multihead = false;
-        if (oq != NULL)
-            free(oq);
+        free(oq);
         return false;
     }
     if (no == 1) {


### PR DESCRIPTION
free(NULL) is noop. We don't need to check for this.