### PR TITLE
Allow canceling the selection of another window through a `cancel` key

### DIFF
--- a/doc/alttab.1
+++ b/doc/alttab.1
@@ -7,7 +7,7 @@
 \fBalttab\fR \- the task switcher
 .
 .SH "SYNOPSIS"
-\fBalttab\fR [\fB\-w\fR \fIN\fR] [\fB\-d\fR \fIN\fR] [\fB\-sc\fR \fIN\fR] [\fB\-mk\fR \fIstr\fR] [\fB\-kk\fR \fIstr\fR] [\fB\-bk\fR \fIstr\fR] [\fB\-pk\fR \fIstr\fR] [\fB\-nk\fR \fIstr\fR] [\fB\-mm\fR \fIN\fR] [\fB\-bm\fR \fIN\fR] [\fB\-t\fR \fINxM\fR] [\fB\-i\fR \fINxM\fR] [\fB\-vp\fR \fIstr\fR] [\fB\-p\fR \fIstr\fR] [\fB\-s\fR \fIN\fR] [\fB\-theme\fR \fIname\fR] [\fB\-bg\fR \fIcolor\fR] [\fB\-fg\fR \fIcolor\fR] [\fB\-frame\fR \fIcolor\fR] [\fB\-font\fR \fIname\fR] [\fB\-v\fR|\fB\-vv\fR]
+\fBalttab\fR [\fB\-w\fR \fIN\fR] [\fB\-d\fR \fIN\fR] [\fB\-sc\fR \fIN\fR] [\fB\-mk\fR \fIstr\fR] [\fB\-kk\fR \fIstr\fR] [\fB\-bk\fR \fIstr\fR] [\fB\-pk\fR \fIstr\fR] [\fB\-nk\fR \fIstr\fR] [\fB\-ck\fR \fIstr\fR] [\fB\-mm\fR \fIN\fR] [\fB\-bm\fR \fIN\fR] [\fB\-t\fR \fINxM\fR] [\fB\-i\fR \fINxM\fR] [\fB\-vp\fR \fIstr\fR] [\fB\-p\fR \fIstr\fR] [\fB\-s\fR \fIN\fR] [\fB\-theme\fR \fIname\fR] [\fB\-bg\fR \fIcolor\fR] [\fB\-fg\fR \fIcolor\fR] [\fB\-frame\fR \fIcolor\fR] [\fB\-font\fR \fIname\fR] [\fB\-v\fR|\fB\-vv\fR]
 .
 .SH "DESCRIPTION"
 The task switcher designed for minimalistic window managers or standalone X11 session\.
@@ -154,6 +154,16 @@ default: no key assigned
 .
 .IP
 Keysym of auxiliary \'next\' key\. For example, Right, L\.
+.
+.TP
+\fB\-ck\fR \fIstr\fR
+resource: alttab\.cancelkey\.keysym
+.
+.br
+default: Escape
+.
+.IP
+Keysym of auxiliary \'cancel\' key\. For example, Escape\.
 .
 .TP
 \fB\-mm\fR \fINUM\fR

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -110,6 +110,7 @@ static int use_args_and_xrm(int *argc, char **argv)
         {"-bk", "*backscroll.keysym", XrmoptionSepArg, NULL},
         {"-pk", "*prevkey.keysym", XrmoptionSepArg, NULL},
         {"-nk", "*nextkey.keysym", XrmoptionSepArg, NULL},
+        {"-ck", "*cancelkey.keysym", XrmoptionSepArg, NULL},
         {"-t", "*tile.geometry", XrmoptionSepArg, NULL},
         {"-i", "*icon.geometry", XrmoptionSepArg, NULL},
         {"-vp", "*viewport", XrmoptionSepArg, NULL},
@@ -243,6 +244,7 @@ static int use_args_and_xrm(int *argc, char **argv)
 #define  KC  g.option_keyCode
 #define  prevC  g.option_prevCode
 #define  nextC  g.option_nextCode
+#define  cancelC  g.option_cancelCode
 #define  GMM  g.option_modMask
 #define  GBM  g.option_backMask
 
@@ -265,6 +267,11 @@ static int use_args_and_xrm(int *argc, char **argv)
     if (ksi == -1)
         die("%s\n", errmsg);
     nextC = ksi != 0 ? ksi : XKeysymToKeycode(dpy, DEFNEXTKEYKS);
+
+    ksi = ksym_option_to_keycode(&db, XRMAPPNAME, "cancelkey", &errmsg);
+    if (ksi == -1)
+        die("%s\n", errmsg);
+    cancelC = ksi != 0 ? ksi : XKeysymToKeycode(dpy, DEFCANCELKS);
 
     switch (xresource_load_int(&db, XRMAPPNAME, "modifier.mask", &(GMM))) {
     case 1:
@@ -552,6 +559,14 @@ int main(int argc, char **argv)
                             uiNextWindow();
                         }
                     }
+                } else if (ev.xkey.keycode == g.option_cancelCode) { // escape
+                    // additional check, see #97
+                    XQueryKeymap(dpy, keys_pressed);
+                    if (!(keys_pressed[octet] & kmask)) {
+                        msg(1, "Wrong modifier, skip event\n");
+                        continue;
+                    }
+                    uiSelectWindow(0);
                 } else {  // non-tab
                     switch (isPrevNextKey(ev.xkey.keycode)) {
                     case 1:

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -57,6 +57,7 @@ along with alttab.  If not, see <http://www.gnu.org/licenses/>.
 #define DEFKEYKS    XK_Tab
 #define DEFPREVKEYKS    XK_VoidSymbol
 #define DEFNEXTKEYKS    XK_VoidSymbol
+#define DEFCANCELKS XK_Escape
 
 #include "icon.h"
 
@@ -178,6 +179,7 @@ typedef struct {
     unsigned int option_modMask, option_backMask;
     KeyCode option_modCode, option_keyCode;
     KeyCode option_prevCode, option_nextCode;
+    KeyCode option_cancelCode;
     Color color[NCOLORS];
     GC gcDirect, gcReverse, gcFrame;    // used in both gui.c and win.c
     unsigned int ignored_modmask;

--- a/src/gui.c
+++ b/src/gui.c
@@ -251,6 +251,14 @@ static int grabKeysAtUiShow(bool grabUngrab)
             return 0;
         }
     }
+    if (g.option_cancelCode != 0) {
+        if (!changeKeygrab
+            (root, grabUngrab, g.option_cancelCode, g.option_modMask,
+             g.ignored_modmask)) {
+            msg(0, grabhint, g.option_cancelCode, g.option_modMask, g.ignored_modmask);
+            return 0;
+        }
+    }
     return 1;
 }
 


### PR DESCRIPTION
This is probably more of a feature-request/proof-of-concept, my C is rusty, and my X11 skills are non-existing :)

I'm regularly switching between Linux/i3 and a macOS environment, and somehow I have a finger memory for pressing the alt-tab thing, look at the windows, and then cancel the selection and just stay where I am.

After a few times too often now using alttab on the linux environment and then ending up on a different window I decided to have a look whether I can just add such a "cancel the selection" key. Turns out, it was fairly trivial to do.

This PR adds a `cancel key` configuration, and when that is pressed simply sets the selected window index to 0. What do you think, is this helpful for other users?