### PR TITLE
Extern ee_ignored and ee_complain

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -25,6 +25,9 @@ extern Display *dpy;
 extern int scr;
 extern Window root;
 
+XErrorEvent *ee_ignored;
+bool ee_complain;
+
 // PUBLIC:
 
 //

--- a/src/util.h
+++ b/src/util.h
@@ -47,8 +47,8 @@ typedef struct {
 #define MAXNAMESZ   256
 #endif
 
-XErrorEvent *ee_ignored;
-bool ee_complain;
+extern XErrorEvent *ee_ignored;
+extern bool ee_complain;
 
 // values for pixel composite transformations
 // which are constant per entire image


### PR DESCRIPTION
These were in util.h without an extern, which meant there was a multiple definition error.
Now they are only declared in util.h and defined in a single place (util.c).