### PR TITLE
implement optional border around the alttab-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or standalone X11 session.
   alttab  [-w N] [-d N] [-sc N] [-mk <str>] [-kk <str>] [-bk <str>]
   [-pk <str>] [-nk <str>] [-ck <str>] [-mm <N>] [-bm <N>]
   [-t NxM] [-i NxM] [-vp str] [-p str] [-s N] [-theme name] [-bg color]
-  [-fg color] [-frame color] [-font name] [-v|-vv]
+  [-fg color] [-frame color] [-border color] [-borderw <N>] [-font name] [-v|-vv]
 ```
 (see man page for details)
 <!-- ronn page has elements invalid for github markdown, don't link to it -->

--- a/doc/alttab.1
+++ b/doc/alttab.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBalttab\fR \- the task switcher
 .SH "SYNOPSIS"
-\fBalttab\fR [\fB\-w\fR \fIN\fR] [\fB\-d\fR \fIN\fR] [\fB\-sc\fR \fIN\fR] [\fB\-mk\fR \fIstr\fR] [\fB\-kk\fR \fIstr\fR] [\fB\-bk\fR \fIstr\fR] [\fB\-pk\fR \fIstr\fR] [\fB\-nk\fR \fIstr\fR] [\fB\-mm\fR \fIN\fR] [\fB\-bm\fR \fIN\fR] [\fB\-t\fR \fINxM\fR] [\fB\-i\fR \fINxM\fR] [\fB\-vp\fR \fIstr\fR] [\fB\-p\fR \fIstr\fR] [\fB\-s\fR \fIN\fR] [\fB\-theme\fR \fIname\fR] [\fB\-bg\fR \fIcolor\fR] [\fB\-fg\fR \fIcolor\fR] [\fB\-frame\fR \fIcolor\fR] [\fB\-font\fR \fIname\fR] [\fB\-v\fR|\fB\-vv\fR]
+\fBalttab\fR [\fB\-w\fR \fIN\fR] [\fB\-d\fR \fIN\fR] [\fB\-sc\fR \fIN\fR] [\fB\-mk\fR \fIstr\fR] [\fB\-kk\fR \fIstr\fR] [\fB\-bk\fR \fIstr\fR] [\fB\-pk\fR \fIstr\fR] [\fB\-nk\fR \fIstr\fR] [\fB\-mm\fR \fIN\fR] [\fB\-bm\fR \fIN\fR] [\fB\-t\fR \fINxM\fR] [\fB\-i\fR \fINxM\fR] [\fB\-vp\fR \fIstr\fR] [\fB\-p\fR \fIstr\fR] [\fB\-s\fR \fIN\fR] [\fB\-theme\fR \fIname\fR] [\fB\-bg\fR \fIcolor\fR] [\fB\-fg\fR \fIcolor\fR] [\fB\-frame\fR \fIcolor\fR] [\fB\-border\fR \fIcolor\fR] [\fB\-borderw\fR \fIN\fR] [\fB\-font\fR \fIname\fR] [\fB\-v\fR|\fB\-vv\fR]
 .SH "DESCRIPTION"
 The task switcher designed for minimalistic window managers or standalone X11 session\.
 .P
@@ -227,6 +227,20 @@ resource: alttab\.framecolor
 default: \fI#a0abab\fR
 .IP
 Color of frame around selected tile\.
+.TP
+\fB\-border\fR \fIcolor\fR
+resource: alttab\.bordercolor
+.br
+default: \fIblack\fR
+.IP
+Color of border around alttab-window\.
+.TP
+\fB\-borderw\fR \fINUMBER\fR
+resource: alttab\.borderwidth
+.br
+default: \fI0\fR
+.IP
+Width of border around alttab-window\.
 .TP
 \fB\-font\fR \fIname\fR
 resource: alttab\.font

--- a/doc/alttab.1
+++ b/doc/alttab.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "ALTTAB" "1" "September 2021" ""
+.TH "ALTTAB" "1" "October 2021" ""
 .SH "NAME"
 \fBalttab\fR \- the task switcher
 .SH "SYNOPSIS"
@@ -233,14 +233,14 @@ resource: alttab\.bordercolor
 .br
 default: \fIblack\fR
 .IP
-Color of border around alttab-window\.
+Color of additional border around the entire switcher\.
 .TP
-\fB\-borderw\fR \fINUMBER\fR
+\fB\-borderw\fR \fIN\fR
 resource: alttab\.borderwidth
 .br
-default: \fI0\fR
+default: \fI0\fR (no border)
 .IP
-Width of border around alttab-window\.
+Width of border above\.
 .TP
 \fB\-font\fR \fIname\fR
 resource: alttab\.font

--- a/doc/alttab.1.ronn
+++ b/doc/alttab.1.ronn
@@ -266,16 +266,16 @@ The following three options accept color names or <#rrggbb>. Special value <&#95
     Color of frame around selected tile.
 
   * `-border` <color>:
-    resource: alttab.bordercolor
+    resource: alttab.bordercolor  
     default: <black>
 
-    Color of border around alttab-window.
+    Color of additional border around the entire switcher.
 
   * `-borderw` <N>:
-    resource: alttab.borderwidth
-    default: <0>
+    resource: alttab.borderwidth  
+    default: <0> (no border)
 
-    Width of border around alttab-window.
+    Width of border above.
 
   * `-font` <name>:
     resource: alttab.font  

--- a/doc/alttab.1.ronn
+++ b/doc/alttab.1.ronn
@@ -16,7 +16,7 @@ alttab(1) -- the task switcher
 
 ## SYNOPSIS
 
-`alttab` [`-w` <N>] [`-d` <N>] [`-sc` <N>] [`-mk` <str>] [`-kk` <str>] [`-bk` <str>] [`-pk` <str>] [`-nk` <str>] [`-mm` <N>] [`-bm` <N>] [`-t` <NxM>] [`-i` <NxM>] [`-vp` <str>] [`-p` <str>] [`-s` <N>] [`-theme` <name>] [`-bg` <color>] [`-fg` <color>] [`-frame` <color>] [`-font` <name>] [`-v`\|`-vv`]
+`alttab` [`-w` <N>] [`-d` <N>] [`-sc` <N>] [`-mk` <str>] [`-kk` <str>] [`-bk` <str>] [`-pk` <str>] [`-nk` <str>] [`-mm` <N>] [`-bm` <N>] [`-t` <NxM>] [`-i` <NxM>] [`-vp` <str>] [`-p` <str>] [`-s` <N>] [`-theme` <name>] [`-bg` <color>] [`-fg` <color>] [`-frame` <color>] [`-border` <color>] [`-borderw` <N>] [`-font` <name>] [`-v`\|`-vv`]
 
 ## DESCRIPTION
 
@@ -264,6 +264,18 @@ The following three options accept color names or <#rrggbb>. Special value <&#95
     default: <#a0abab>
 
     Color of frame around selected tile.
+
+  * `-border` <color>:
+    resource: alttab.bordercolor
+    default: <black>
+
+    Color of border around alttab-window.
+
+  * `-borderw` <N>:
+    resource: alttab.borderwidth
+    default: <0>
+
+    Width of border around alttab-window.
 
   * `-font` <name>:
     resource: alttab.font  

--- a/doc/alttab.ad
+++ b/doc/alttab.ad
@@ -66,11 +66,11 @@ alttab.foreground:      #600000
 ! Random dark frame
 alttab.framecolor:      _rnd_low
 
-! Blue border
-! alttab.bordercolor:     #0000FF
+! Show X11 window border around the switcher
+!alttab.borderwidth:     4
 
-! Show a border with specified width. Set to 0 to disable border.
-! alttab.borderwidth:     4
+! Blue border
+!alttab.bordercolor:     #0000FF
 
 ! Bigger font
 !alttab.font:           xft:DejaVu Sans Condensed-18

--- a/doc/alttab.ad
+++ b/doc/alttab.ad
@@ -66,6 +66,12 @@ alttab.foreground:      #600000
 ! Random dark frame
 alttab.framecolor:      _rnd_low
 
+! Blue border
+! alttab.bordercolor:     #0000FF
+
+! Show a border with specified width. Set to 0 to disable border.
+! alttab.borderwidth:     4
+
 ! Bigger font
 !alttab.font:           xft:DejaVu Sans Condensed-18
 

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -69,7 +69,7 @@ Options:\n\
    -fg color  foreground color\n\
 -frame color  active frame color\n\
 -border color border color\n\
--borderw N    border color\n\
+-borderw N    border width\n\
  -font name   font name in the form xft:fontconfig_pattern\n\
   -v|-vv      verbose\n\
     -h        help\n\

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -68,6 +68,8 @@ Options:\n\
    -bg color  background color\n\
    -fg color  foreground color\n\
 -frame color  active frame color\n\
+-border color border color\n\
+-borderw N    border color\n\
  -font name   font name in the form xft:fontconfig_pattern\n\
   -v|-vv      verbose\n\
     -h        help\n\
@@ -90,7 +92,7 @@ static int use_args_and_xrm(int *argc, char **argv)
     unsigned int wmindex, dsindex, scindex, isrc;
     char *gtile, *gicon, *gview, *gpos;
     int x, y;
-    unsigned int w, h;
+    unsigned int w, h, bw;
     int xpg;
     char *s;
     char *rm;
@@ -121,6 +123,8 @@ static int use_args_and_xrm(int *argc, char **argv)
         {"-bg", "*background", XrmoptionSepArg, NULL},
         {"-fg", "*foreground", XrmoptionSepArg, NULL},
         {"-frame", "*framecolor", XrmoptionSepArg, NULL},
+        {"-border", "*bordercolor", XrmoptionSepArg, NULL},
+        {"-borderw", "*borderwidth", XrmoptionSepArg, NULL},
         {"-font", "*font", XrmoptionSepArg, NULL},
     };
     const char *inv = "invalid %s, use -h for help\n";
@@ -345,6 +349,22 @@ static int use_args_and_xrm(int *argc, char **argv)
     msg(0, "%dx%d tile, %dx%d icon\n",
         g.option_tileW, g.option_tileH, g.option_iconW, g.option_iconH);
 
+    switch (xresource_load_int(&db, XRMAPPNAME, "borderwidth", &bw)) {
+    case 1:
+        if (bw >= BORDER_MIN)
+          g.option_borderW = bw;
+        else
+          die(inv, "borderw argument range");
+        break;
+    case 0:
+        g.option_borderW = DEFBORDERW;
+        break;
+    case -1:
+        die(inv, "borderw argument");
+        break;
+    }
+    msg(0, "borderw: %d\n", g.option_borderW);
+
     bzero(&(g.option_vp), sizeof(g.option_vp));
     g.option_vp_mode = VP_DEFAULT;
     gview = xresource_load_string(&db, XRMAPPNAME, "viewport");
@@ -423,6 +443,8 @@ static int use_args_and_xrm(int *argc, char **argv)
     g.color[COLFG].name = s ? s : DEFCOLFG;
     s = xresource_load_string(&db, XRMAPPNAME, "framecolor");
     g.color[COLFRAME].name = s ? s : DEFCOLFRAME;
+    s = xresource_load_string(&db, XRMAPPNAME, "bordercolor");
+    g.color[COLBORDER].name = s ? s : DEFCOLBORDER;
 
     s = xresource_load_string(&db, XRMAPPNAME, "font");
     if (s) {

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -36,6 +36,7 @@ along with alttab.  If not, see <http://www.gnu.org/licenses/>.
 #define DEFTILEH    128
 #define DEFICONW    32
 #define DEFICONH    32
+#define DEFBORDERW  0
 #define DEFTHEME    "hicolor"
 #define FRAME_W     8
 //#define DEFFONT   "xft:DejaVu Sans Condensed-10"
@@ -44,10 +45,12 @@ along with alttab.  If not, see <http://www.gnu.org/licenses/>.
 #define COLBG       0
 #define COLFG       1
 #define COLFRAME    2
-#define NCOLORS     3
+#define COLBORDER   3
+#define NCOLORS     4
 #define DEFCOLBG    "black"
 #define DEFCOLFG    "grey"
 #define DEFCOLFRAME "#a0abab"
+#define DEFCOLBORDER "black"
 
 #define XDEPTH      24          // TODO: get rid of this
 
@@ -152,6 +155,8 @@ typedef struct {
     char *option_font;
     int option_tileW, option_tileH;
     int option_iconW, option_iconH;
+#define BORDER_MIN      0
+    int option_borderW;
 #define VP_FOCUS        0
 #define VP_POINTER      1
 #define VP_TOTAL        2

--- a/src/gui.c
+++ b/src/gui.c
@@ -507,9 +507,9 @@ int uiShow(bool direction)
     unsigned long valuemask = CWBackPixel | CWBorderPixel | CWOverrideRedirect;
     XSetWindowAttributes attributes;
     attributes.background_pixel = g.color[COLBG].xcolor.pixel;
-    attributes.border_pixel = g.color[COLFRAME].xcolor.pixel;
+    attributes.border_pixel = g.color[COLBORDER].xcolor.pixel;
     attributes.override_redirect = 1;
-    uiwin = XCreateWindow(dpy, root, uiwinX, uiwinY, uiwinW, uiwinH, 0, // border_width
+    uiwin = XCreateWindow(dpy, root, uiwinX, uiwinY, uiwinW, uiwinH, g.option_borderW, // border_width
                           CopyFromParent,   // depth
                           InputOutput,  // class
                           CopyFromParent,   // visual


### PR DESCRIPTION
## Feature

Add the ability to draw a border around the alttab-window by using the
native X-window-border. The border can be customized with the following
options from the commandline:

- **-border:**  defines the border-color (default: black)
- **-borderw:** defines the border-width (default: 0)

## Reason

I would like to add this feature to alttab because I like to have a border around all my windows which is defined by my window-manager. However, because the alttab-window sets the `override-redirect` attribute my window manager [herbstluftwm](https://github.com/herbstluftwm/herbstluftwm) doesn't manage the alttab-window and hence doesn't draw a border around it.

https://github.com/sagb/alttab/blob/1c0754e6d2da346a08b06725ba716350553edf48/src/gui.c#L511

## Example 1

The following screenshot was generated with

```sh
alttab -borderw 8 -border red
```

![alttab-border](https://user-images.githubusercontent.com/36510152/129484369-67e5e7f4-f851-4675-ad63-5fd921c7b539.png)

## Example 2

This is how I personally use it. If you accept the PR you can also upload this screen shot to the README if you want. I generated it with the following command:

```sh
alttab -bg '#2e3440' -fg "#2e3440" -frame "#4c566a" -border black -borderw 4 -t 64x64 -i 64x64
```

I am using the [nord-theme](https://www.nordtheme.com/) colors.

![2021-08-15-184010_232x88_scrot](https://user-images.githubusercontent.com/36510152/129485897-a7162f8e-83ac-40e2-9976-152b6a7572c7.png)