### PR TITLE
make sure all test X clients connect to the Xvfb instance

### DIFF
--- a/test/run-in-xvfb.test
+++ b/test/run-in-xvfb.test
@@ -54,9 +54,10 @@ start_x()
         sh -c "mkdir -p /tmp/.X11-unix ; chmod 1777 /tmp/.X11-unix" >/dev/null
     Xvfb :200 -ac &
     export xvfb=$!
+    export DISPLAY=:200
     for ms100 in `seq 1 50` ; do
         sleep 0.1
-        if DISPLAY=:200 xprop -root >/dev/null ; then
+        if xprop -root >/dev/null ; then
             return
         fi
     done
@@ -75,7 +76,7 @@ stop_x()
 
 start_alttab()
 {
-    DISPLAY=:200 "$ALTTAB" -w 0 -vv &
+    "$ALTTAB" -w 0 -vv &
     export alttab=$!
     sleep 1
 }
@@ -92,7 +93,7 @@ open_sample_windows()
 {
     eyes=""
     for c in `seq 1 7` ; do
-        DISPLAY=:200 xeyes &
+        xeyes &
         eyes="${eyes} $!"
     done
     export eyes
@@ -109,7 +110,6 @@ close_sample_windows()
 
 alttab_simple_cycle()
 {
-    DISPLAY=:200
     xdotool keydown Alt_L
     for c in $(seq 1 20); do
         sleep 0.1


### PR DESCRIPTION
Export the DISPLAY variable immediately after starting Xvfb so that any X clients started after that, including the recently added xdotool, will be sure to use it. Without this change, setting DISPLAY (without exporting it) in alttab_simple_cycle() does not work when that variable is not already exported, e.g. when running in an isolated environment like a container or a chroot environment.