### PR TITLE
Add a desktop increment (-di) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or standalone X11 session.
   [-pk <str>] [-nk <str>] [-ck <str>] [-dk <str>] [-mm <N>] [-bm <N>]
   [-t NxM] [-i NxM] [-vp str] [-p str] [-s N] [-theme name] [-bg color]
   [-fg color] [-frame color] [-inact color] [-bc color] [-bw <N>]
-  [-font name] [-vertical] [-sortmin] [-e] [-b N] [-ns] [-v|-vv]
+  [-font name] [-vertical] [-sortmin] [-e] [-b N] [-di] [-ns] [-v|-vv]
 ```
 (see man page for details)
 <!-- ronn page has elements invalid for github markdown, don't link to it -->

--- a/doc/README
+++ b/doc/README
@@ -5,7 +5,7 @@ or standalone X11 session.
   [-pk <str>] [-nk <str>] [-ck <str>] [-dk <str>] [-mm <N>] [-bm <N>]
   [-t NxM] [-i NxM] [-vp str] [-p str] [-s N] [-theme name] [-bg color]
   [-fg color] [-frame color] [-inact color] [-bc color] [-bw N]
-  [-font name] [-vertical] [-sortmin] [-e] [-b N] [-ns] [-v|-vv]
+  [-font name] [-vertical] [-sortmin] [-e] [-b N] [-di] [-ns] [-v|-vv]
 
 (see man page for details)
 

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -59,6 +59,7 @@ Options:\n\
    -nk str    keysym of 'next' key\n\
    -ck str    keysym of 'cancel' key\n\
    -dk str    keysym of 'kill' key\n\
+   -di        increment desktop number\n\
    -mm N      (obsoleted) main modifier mask\n\
    -bm N      (obsoleted) backward scroll modifier mask\n\
     -t NxM    tile geometry\n\
@@ -123,6 +124,7 @@ static int use_args_and_xrm(int *argc, char **argv)
         {"-nk", "*nextkey.keysym", XrmoptionSepArg, NULL},
         {"-ck", "*cancelkey.keysym", XrmoptionSepArg, NULL},
         {"-dk", "*killkey.keysym", XrmoptionSepArg, NULL},
+        {"-di", "*desktopincrement", XrmoptionIsArg, NULL},
         {"-t", "*tile.geometry", XrmoptionSepArg, NULL},
         {"-i", "*icon.geometry", XrmoptionSepArg, NULL},
         {"-vp", "*viewport", XrmoptionSepArg, NULL},
@@ -338,6 +340,10 @@ static int use_args_and_xrm(int *argc, char **argv)
         GMM, GBM, MC, KC);
     msg(0, "cancelCode %d, killCode %d\n",
         cancelC, killC);
+
+    s = xresource_load_string(&db, XRMAPPNAME, "desktopincrement");
+    g.option_desktop_increment = (s != NULL);
+    msg(0, "desktop_increment: %d\n", g.option_desktop_increment);
 
     g.option_tileW = DEFTILEW;
     g.option_tileH = DEFTILEH;

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -59,7 +59,7 @@ Options:\n\
    -nk str    keysym of 'next' key\n\
    -ck str    keysym of 'cancel' key\n\
    -dk str    keysym of 'kill' key\n\
-   -di        increment desktop number\n\
+   -di        increment desktop index\n\
    -mm N      (obsoleted) main modifier mask\n\
    -bm N      (obsoleted) backward scroll modifier mask\n\
     -t NxM    tile geometry\n\

--- a/src/alttab.c
+++ b/src/alttab.c
@@ -59,7 +59,6 @@ Options:\n\
    -nk str    keysym of 'next' key\n\
    -ck str    keysym of 'cancel' key\n\
    -dk str    keysym of 'kill' key\n\
-   -di        increment desktop index\n\
    -mm N      (obsoleted) main modifier mask\n\
    -bm N      (obsoleted) backward scroll modifier mask\n\
     -t NxM    tile geometry\n\
@@ -79,6 +78,7 @@ Options:\n\
   -sortmin    sort minimized windows last\n\
     -e        keep switcher after keys release\n\
     -b N      bottom line: 0=no, 1=desktop, 2=user\n\
+   -di        increment desktop indices\n\
    -ns        ignore window request to skip it in taskbar\n\
   -v|-vv      verbose\n\
     -h        help\n\
@@ -124,7 +124,6 @@ static int use_args_and_xrm(int *argc, char **argv)
         {"-nk", "*nextkey.keysym", XrmoptionSepArg, NULL},
         {"-ck", "*cancelkey.keysym", XrmoptionSepArg, NULL},
         {"-dk", "*killkey.keysym", XrmoptionSepArg, NULL},
-        {"-di", "*desktopincrement", XrmoptionIsArg, NULL},
         {"-t", "*tile.geometry", XrmoptionSepArg, NULL},
         {"-i", "*icon.geometry", XrmoptionSepArg, NULL},
         {"-vp", "*viewport", XrmoptionSepArg, NULL},
@@ -141,6 +140,7 @@ static int use_args_and_xrm(int *argc, char **argv)
         {"-vertical", "*vertical", XrmoptionIsArg, NULL},
         {"-e", "*keep", XrmoptionIsArg, NULL},
         {"-b", "*bottomline", XrmoptionSepArg, NULL},
+        {"-di", "*desktopincrement", XrmoptionIsArg, NULL},
         {"-sortmin", "*sortmin", XrmoptionIsArg, NULL},
         {"-ns", "*noskiptaskbar", XrmoptionIsArg, NULL}
     };
@@ -341,10 +341,6 @@ static int use_args_and_xrm(int *argc, char **argv)
     msg(0, "cancelCode %d, killCode %d\n",
         cancelC, killC);
 
-    s = xresource_load_string(&db, XRMAPPNAME, "desktopincrement");
-    g.option_desktop_increment = (s != NULL);
-    msg(0, "desktop_increment: %d\n", g.option_desktop_increment);
-
     g.option_tileW = DEFTILEW;
     g.option_tileH = DEFTILEH;
     gtile = xresource_load_string(&db, XRMAPPNAME, "tile.geometry");
@@ -528,6 +524,10 @@ static int use_args_and_xrm(int *argc, char **argv)
         break;
     }
     msg(0, "bottomline: %d\n", g.option_bottom_line);
+
+    s = xresource_load_string(&db, XRMAPPNAME, "desktopincrement");
+    g.option_desktop_increment = (s != NULL);
+    msg(0, "desktop_increment: %d\n", g.option_desktop_increment);
 
     s = xresource_load_string(&db, XRMAPPNAME, "noskiptaskbar");
     g.option_no_skip_taskbar = (s != NULL);

--- a/src/alttab.h
+++ b/src/alttab.h
@@ -153,6 +153,7 @@ typedef struct {
 #define DESK_MAX        4
 #define DESK_DEFAULT    DESK_CURRENT
     int option_desktop;
+    bool option_desktop_increment;
 #define SCR_MIN        0
 #define SCR_CURRENT    0
 #define SCR_ALL        1

--- a/src/win.c
+++ b/src/win.c
@@ -556,14 +556,16 @@ endIcon:
     WI.bottom_line[0] = '\0';
     long unsigned int nws, *pid;
     char procd[32];
+    unsigned long desktop_val;
     int sr;
     struct stat st;
     struct passwd *gu;
     switch(g.option_bottom_line) {
         case BL_DESKTOP:
-            if (desktop != DESKTOP_UNKNOWN)
-                snprintf(WI.bottom_line, MAXNAMESZ, "%ld", desktop);
-            else
+            if (desktop != DESKTOP_UNKNOWN) {
+                desktop_val = (g.option_desktop_increment) ? desktop + 1 : desktop;
+                snprintf(WI.bottom_line, MAXNAMESZ, "%ld", desktop_val);
+            } else
                 strncpy(WI.bottom_line, "?", 2);
             break;
         case BL_USER:


### PR DESCRIPTION
By default the program uses Freedesktop standard indicies for workspaces which are zero-based. This PR add a `-di` option (stands for `desktop increment`) that just increments those indices. The feature closes #151, #166, and #190.

<img width="1920" height="1080" alt="Screenshot from 2026-04-10 14-39-11" src="https://github.com/user-attachments/assets/d1d7306d-2933-4787-a828-3dadc4726a92" />
