### PR TITLE
Add show desktop names

### DIFF
--- a/doc/alttab.1
+++ b/doc/alttab.1
@@ -1,6 +1,6 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "ALTTAB" "1" "November 2025" ""
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "ALTTAB" "1" "April 2026" ""
 .SH "NAME"
 \fBalttab\fR \- the task switcher
 .SH "SYNOPSIS"
@@ -27,7 +27,7 @@ Set this value manually, as it's not autodetected\. Only top\-level viewable chi
 .IP
 \fI1\fR: EWMH compatible\.
 .IP
-Compatible WM list is in [SEE ALSO] below\. alttab functions in xmonad (EWMH must be allowed, details in doc/wm\-setup\.md), i3, evilwm, xfwm4, metacity, jwm, openbox, fluxbox, icewm, enlightenment, blackbox, aewm, fvwm, sawfish, bspwm\. The following WMs support EWMH partially but work in \fB\-w 1\fR mode too: dwm (issue #9), matchbox (issue #34), windowmaker (issue #9), xpra (issue #37), cwm (issue #35), ctwm (issue #39), lwm (issue #40), awesome (issue #41)\.
+Compatible WM list is in \fISEE ALSO\fR below\. alttab functions in xmonad (EWMH must be allowed, details in doc/wm\-setup\.md), i3, evilwm, xfwm4, metacity, jwm, openbox, fluxbox, icewm, enlightenment, blackbox, aewm, fvwm, sawfish, bspwm\. The following WMs support EWMH partially but work in \fB\-w 1\fR mode too: dwm (issue #9), matchbox (issue #34), windowmaker (issue #9), xpra (issue #37), cwm (issue #35), ctwm (issue #39), lwm (issue #40), awesome (issue #41)\.
 .IP
 \fI2\fR: Ratpoison\.
 .IP
@@ -267,7 +267,7 @@ resource: alttab\.font
 .br
 default: \fIxft:sans\-10\fR
 .IP
-Label font name in format: \fBxft:fontconfig_pattern\fR, like in emacs and rxvt\. See [SEE ALSO] for fontconfig pattern\. It's neither GTK font pattern nor legacy XLFD\.
+Label font name in format: \fBxft:fontconfig_pattern\fR, like in emacs and rxvt\. See \fISEE ALSO\fR for fontconfig pattern\. It's neither GTK font pattern nor legacy XLFD\.
 .P
 Your Xresources database probably already has *background, *foreground or *font wildcard definitions, which alttab will obey\. Precedence order (preferred first):
 .P
@@ -307,7 +307,7 @@ Content of auxiliary line at the bottom of each tile\. \fINUMBER\fR must be betw
 .IP
 \fI0\fR: Empty\.
 .IP
-\fI1\fR: Index of desktop to which the window belongs, starting from zero\.
+\fI1\fR: Name of desktop to which the window belongs\.
 .IP
 \fI2\fR: User name\. Requires _NET_WM_PID freedesktop property and /proc file system\.
 .TP

--- a/doc/alttab.1.ronn
+++ b/doc/alttab.1.ronn
@@ -334,7 +334,7 @@ Your Xresources database probably already has \*background, \*foreground or \*fo
 
       <0>: Empty.
 
-      <1>: Index of desktop to which the window belongs, starting from zero.
+      <1>: Name of desktop to which the window belongs.
 
       <2>: User name. Requires _NET_WM_PID freedesktop property and /proc file system.
 
@@ -353,19 +353,19 @@ Your Xresources database probably already has \*background, \*foreground or \*fo
   * `-h`:
     short help
 
-##CAVEATS
+## CAVEATS
 
 Run alttab after WM, or autodetection will fail.
 
-##AUTHOR
+## AUTHOR
 
 Copyright 2017-2025 Alexander Kulak `<sa-dev AT odd POINT systems>`.
 
-##REPORTING BUGS
+## REPORTING BUGS
 
 Please [report issues on github](https://github.com/sagb/alttab/issues).
 
-##SEE ALSO
+## SEE ALSO
 
 [EWMH compatible WM list](https://en.wikipedia.org/wiki/Extended_Window_Manager_Hints#List_of_window_managers_that_support_Extended_Window_Manager_Hints).
 

--- a/doc/alttab.ad
+++ b/doc/alttab.ad
@@ -87,7 +87,7 @@ alttab.framecolor:      _rnd_low
 ! Keep switcher after Alt-Tab release
 !alttab.keep:           true
 
-! Force showing desktop number at the bottom of each tile
+! Force showing desktop name at the bottom of each tile
 !alttab.bottomline:     1
 
 ! Ignore _NET_WM_STATE_SKIP_TASKBAR

--- a/src/win.c
+++ b/src/win.c
@@ -141,7 +141,7 @@ static void print_winlist(void)
 }
 
 //
-//  Find a desktop name for a specific destkop
+//  Find a desktop name for a specific desktop
 //
 size_t get_desktop_name(Window win, unsigned long desktop, char* name) {
     Atom dnames = XInternAtom(dpy, "_NET_DESKTOP_NAMES", False);
@@ -606,7 +606,7 @@ endIcon:
     WI.bottom_line[0] = '\0';
     long unsigned int nws, *pid;
     char dname[MAXNAMESZ] = "?";
-    char procd[32] = "?";
+    char procd[32];
     int sr;
     struct stat st;
     struct passwd *gu;

--- a/src/win.c
+++ b/src/win.c
@@ -140,6 +140,56 @@ static void print_winlist(void)
     }
 }
 
+//
+//  Find a desktop name for a specific destkop
+//
+size_t get_desktop_name(Window win, unsigned long desktop, char* name) {
+    Atom dnames = XInternAtom(dpy, "_NET_DESKTOP_NAMES", False);
+    Atom utf8 = XInternAtom(dpy, "UTF8_STRING", False);
+    if (dnames == None || utf8 == None)
+        return 0;
+
+    Atom type;
+    int format;
+    unsigned long n, leftover;
+    unsigned char *data = NULL;
+
+    if (XGetWindowProperty(dpy, root, dnames,
+                           0, (~0l), False,
+                           utf8,
+                           &type, &format,
+                           &n, &leftover, &data) == Success && data != NULL) {
+        if (type != utf8 || format != 8 || n == 0) {
+            XFree(data);
+
+            return 0;
+        }
+
+        char *ptr = (char *)data;
+        unsigned long offset = 0;
+        int i = 0;
+
+        while (offset < n) {
+            size_t len = strlen(ptr);
+            if (i == desktop) {
+                strncpy(name, ptr, MAXNAMESZ - 1);
+                name[MAXNAMESZ - 1] = '\0';
+
+                XFree(data);
+                return len;
+            }
+
+            ptr += len + 1;
+            offset += len + 1;
+            i++;
+        }
+
+        XFree(data);
+    }
+    // it wasn't able to retrieve information
+    return 0;
+}
+
 // PUBLIC
 
 //
@@ -555,14 +605,19 @@ endIcon:
 
     WI.bottom_line[0] = '\0';
     long unsigned int nws, *pid;
-    char procd[32];
+    char dname[MAXNAMESZ] = "?";
+    char procd[32] = "?";
     int sr;
     struct stat st;
     struct passwd *gu;
     switch(g.option_bottom_line) {
         case BL_DESKTOP:
             if (desktop != DESKTOP_UNKNOWN)
-                snprintf(WI.bottom_line, MAXNAMESZ, "%ld", desktop);
+                if (get_desktop_name(win,desktop, dname)) {
+                    snprintf(WI.bottom_line, MAXNAMESZ, "%s", dname);
+                } else {
+                    snprintf(WI.bottom_line, MAXNAMESZ, "%ld", desktop);
+                }
             else
                 strncpy(WI.bottom_line, "?", 2);
             break;


### PR DESCRIPTION
As #191 with the `-di` option didn't work well for some Windows Managers and [retrieving desktop names from `_NET_DESKTOP_NAMES` ](https://github.com/sagb/alttab/issues/151#issuecomment-1616038093) seems to be the best option, I implemented it. This is how the solution looks like:

<img width="1920" height="1080" alt="Screenshot from 2026-04-12 16-50-55" src="https://github.com/user-attachments/assets/1222e78b-be1d-4e7b-9e2f-5b2e19dc9377" />

This PR closes #151, #166, and #190 (and probably something else).

P.S. it passes `make check`.