### PR TITLE
tests: use kill -0 for alttab liveness check

### DIFF
--- a/test/run-in-xvfb.test
+++ b/test/run-in-xvfb.test
@@ -122,7 +122,7 @@ check_alttab()
 {
     stage="$1" ; comment="$2"
     sleep 0.5
-    if ! ps -p "$alttab" >/dev/null ; then
+    if ! kill -0 "$alttab" >/dev/null 2>&1 ; then
         echo "not ok $stage - $comment"
         exit 1
     else


### PR DESCRIPTION
On Darwin, ps -p can fail with "Operation not permitted" even when the
process is running. Use kill -0 instead that should work everywhere.
