### PR TITLE
Fix termination of strings copied via strncpy()

### DIFF
--- a/src/icon.c
+++ b/src/icon.c
@@ -402,8 +402,10 @@ end_special_1:
         ic = initIcon();
         if (ic == NULL)
             return 0;
-        strncpy(ic->app, app, MAXAPPLEN);
-        strncpy(ic->src_path, pe->fts_path, MAXICONPATHLEN-1);
+        strncpy(ic->app, app, MAXAPPLEN - 1);
+        ic->app[MAXAPPLEN - 1] = '\0';
+        strncpy(ic->src_path, pe->fts_path, MAXICONPATHLEN - 1);
+        ic->src_path[MAXICONPATHLEN - 1] = '\0';
         ic->src_w = ix;
         ic->src_h = iy;
         ic->ext = ext;
@@ -415,7 +417,8 @@ end_special_1:
         // best value: g.option_iconW, H
         // should we replace the icon?
         if (iconMatchBetter(ix, iy, ic->src_w, ic->src_h, false)) {
-            strncpy(ic->src_path, pe->fts_path, MAXICONPATHLEN-1);
+            strncpy(ic->src_path, pe->fts_path, MAXICONPATHLEN - 1);
+            ic->src_path[MAXICONPATHLEN - 1] = '\0';
             ic->src_w = ix;
             ic->src_h = iy;
             ic->ext = ext;

--- a/src/win.c
+++ b/src/win.c
@@ -466,7 +466,8 @@ int addIconFromFiles(WindowInfo * wi)
                 wi->icon_drawable = ic->drawable;
                 wi->icon_mask = ic->mask;
 #ifdef ICON_DEBUG
-                strncpy(wi->icon_src, ic->src_path, MAXNAMESZ);
+                strncpy(wi->icon_src, ic->src_path, MAXNAMESZ - 1);
+                wi->icon_src[MAXNAMESZ - 1] = '\0';
 #endif
                 ret = 1;
                 goto out;
@@ -497,7 +498,8 @@ int addWindowInfo(Window win, int reclevel, int wm_id, unsigned long desktop,
 // 1. get name
 
     if (wm_name) {
-        strncpy(WI.name, wm_name, MAXNAMESZ-1);
+        strncpy(WI.name, wm_name, MAXNAMESZ - 1);
+        WI.name[MAXNAMESZ - 1] = '\0';
     } else {
         // handle COMPOUND WM_NAME, see #177.
         XTextProperty text_prop;


### PR DESCRIPTION
if the string is longer than target buffer, strncpy() does not null terminate. add an explicit null termination on the last char. all others will be filled with zeros by strncpy().